### PR TITLE
Fix the default contribution link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,6 @@ A Julia package for Adaptive Resonance Theory (ART) algorithms.
 [issues-url]: https://github.com/AP6YC/AdaptiveResonance.jl/issues
 [contrib-url]: https://ap6yc.github.io/AdaptiveResonance.jl/dev/man/contributing/
 
-This package is developed and maintained by [Sasha Petrenko](https://github.com/AP6YC) with sponsorship by the [Applied Computational Intelligence Laboratory (ACIL)](https://acil.mst.edu/). This project is supported by grants from the [Night Vision Electronic Sensors Directorate](https://c5isr.ccdc.army.mil/inside_c5isr_center/nvesd/), the [DARPA Lifelong Learning Machines (L2M) program](https://www.darpa.mil/program/lifelong-learning-machines), [Teledyne Technologies](http://www.teledyne.com/), and the [National Science Foundation](https://www.nsf.gov/).
-The material, findings, and conclusions here do not necessarily reflect the views of these entities.
-
 Please read the [documentation](https://ap6yc.github.io/AdaptiveResonance.jl/dev/) for detailed usage and tutorials.
 
 ## Contents
@@ -190,7 +187,10 @@ AdaptiveResonance
 
 ### Authors
 
-- Sasha Petrenko <sap625@mst.edu>
+This package is developed and maintained by [Sasha Petrenko](https://github.com/AP6YC) with sponsorship by the [Applied Computational Intelligence Laboratory (ACIL)](https://acil.mst.edu/). This project is supported by grants from the [Night Vision Electronic Sensors Directorate](https://c5isr.ccdc.army.mil/inside_c5isr_center/nvesd/), the [DARPA Lifelong Learning Machines (L2M) program](https://www.darpa.mil/program/lifelong-learning-machines), [Teledyne Technologies](http://www.teledyne.com/), and the [National Science Foundation](https://www.nsf.gov/).
+The material, findings, and conclusions here do not necessarily reflect the views of these entities.
+
+The users [@aaronpeikert](https://github.com/aaronpeikert), [@hayesall](https://github.com/hayesall), and [@markNZed](https://github.com/markNZed) have graciously contributed their time with reviews and feedback that has greatly improved the project.
 
 ### Software
 


### PR DESCRIPTION
This PR fixes the default contribution link in the README in addition to removing unnecessary internal links.