### PR TITLE
Add target audience, theory, and dynamics to paper

### DIFF
--- a/docs/src/getting-started/whatisart.md
+++ b/docs/src/getting-started/whatisart.md
@@ -19,7 +19,7 @@ Stephen Grossberg's has recently released a book summarizing the work of him, hi
 
 ### ART Dynamics
 
-These are the basics of almost every ART model:
+Nearly every ART model shares a basic set of dynamics:
 
 1. ART models typically have two layers/fields denoted F1 and F2.
 2. The F1 field is the feature representation field.
@@ -29,7 +29,7 @@ These are the basics of almost every ART model:
     This is most easily understood as a weight vector representing a prototype for a class or centroid of a cluster.
 4. An activation function is used to find the order of categories "most activated" for a given sample in F1.
 5. In order of highest activation, a match function is used to compute the agreement between the sample and the categories.
-6. If the match function evaluates to above a threshold value known as the vigilance parameter ($$\rho$$), the weights may be updated according to a learning rule.
+6. If the match function for a category evaluates to a value above a threshold known as the vigilance parameter ($$\rho$$), the weights of that category may be updated according to a learning rule.
 7. If there is complete mismatch across all categories, then a new categories is created according to some instantiation rule.
 
 ### ART Considerations

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -102,3 +102,136 @@
     arxivId = {1905.11437},
     keywords = {Adaptive resonance theory, Classification, Clustering, Regression, Reinforcement learning, Survey, adaptive resonance theory, classification, clustering, corresponding author, explainable, neural networks, regression, reinforcement learning, survey, unsupervised learning}
 }
+
+@inproceedings{Carpenter1991,
+abstract = {Summary form only given. The authors introduced a neural network architecture, called ARTMAP, that autonomously learns to classify arbitrarily many, arbitrarily ordered vectors into recognition categories based on predictive success. This supervised learning system is built up from a pair of adaptive resonance theory modules (ARTa and ARTb) that are capable of self-organizing stable recognition categories in response to arbitrary sequences of input patterns. Tested on a benchmark machine learning database in both online and offline simulations, the ARTMAP system learns orders of magnitude more quickly, efficiently, and accurately than alternative algorithms, and achieves 100% accuracy after training on less than half of the input patterns in the database.},
+annote = {In this paper, Dr. Gail Carpenter introduces the ARTMAP algorithm, which introduces a supervisory learning mechanism to ordinarily unsupervised ART modules. This is done by introducing two ART modules (ARTa and ARTb) and a resonance-based connection between them, mapping categories one modules to labels in another.},
+author = {Carpenter, Gail A. and Grossberg, Stephen and Reynolds, John H.},
+booktitle = {IEEE Conference on Neural Networks for Ocean Engineering},
+doi = {10.1016/0893-6080(91)90012-T},
+file = {:C\:/Users/Sasha/AppData/Local/Mendeley Ltd./Mendeley Desktop/Downloaded/Carpenter, Grossberg, Reynolds - 1991 - ARTMAP Supervised real-time learning and classification of nonstationary data by a self-organizi.pdf:pdf},
+isbn = {0780302052},
+issn = {08936080},
+mendeley-groups = {ART},
+pages = {341--342},
+title = {{ARTMAP: Supervised real-time learning and classification of nonstationary data by a self-organizing neural network}},
+year = {1991}
+}
+
+@article{Carpenter1992,
+    abstract = {— A new neural network architecture is introduced for incremental supervised learning of recognition categories and multidimensional maps in response to arbitrary sequences of analog or binary input vectors, which may represent fuzzy or crisp sets of features. The architecture, called fuzzy ARTMAP, achieves a synthesis of fuzzy logic and adaptive resonance theory (ART) neural networks by exploiting a close formal similarity between the computations of fuzzy subsethood and ART category choice, resonance, and learning. Fuzzy ARTMAP also realizes a new minimax learning rule that conjointly minimizes predictive error and maximizes code compression, or generalization. This is achieved by a match tracking process that increases the ART vigilance parameter by the minimum amount needed to correct a predictive error. As a result, the system automatically learns a minimal number of recognition categories, or “hidden units,” to meet accuracy criteria. Category proliferation is prevented by normalizing input vectors at a preprocessing stage. A normalization procedure called complement coding leads to a symmetric theory in which the and operator (V) and the OR operator (A) of fuzzy logic play complementary roles. Complement coding uses on cells and off cells to represent the input pattern, and preserves individual feature amplitudes while normalizing the total on cell/off cell vector. Learning is stable because all adaptive weights can only decrease in time. Decreasing weights correspond to increasing sizes of category “boxes.” Smaller vigilance values lead to larger category boxes. Improved prediction is achieved by training the system several times using different orderings of the input set. This voting strategy can also be used to assign confidence estimates to competing predictions given small, noisy, or incomplete training sets. Four classes of simulations illustrate fuzzy ARTMAP performance in relation to benchmark backpropagation and genetic algorithm systems. These simulations include (i) finding points inside versus outside a circle; (ii) learning to tell two spirals apart, (iii) incremental approximation of a piecewise-continuous function; and (iv) a letter recognition database. The fuzzy ARTMAP system is also compared with Salzberg's NGE system and with Simpson's FMMC system. {\textcopyright} 1992 IEEE},
+    annote = {In this paper, Drs. Gail Carpenter and Stephen Grossberg demonstrate how .the use of fuzzy set theory operations in the ARTMAP algorithm augment its learning capabilities without sacrificing algorithmic complexity.},
+    author = {Carpenter, Gail A. and Grossberg, Stephen and Markuzon, Natalya and Reynolds, John H. and Rosen, David B.},
+    doi = {10.1109/72.159059},
+    file = {:C\:/Users/Sasha/AppData/Local/Mendeley Ltd./Mendeley Desktop/Downloaded/Carpenter et al. - 1992 - Fuzzy ARTMAP A Neural Network Architecture for Incremental Supervised Learning of Analog Multidimensional Maps.pdf:pdf},
+    issn = {19410093},
+    journal = {IEEE Transactions on Neural Networks},
+    mendeley-groups = {ART},
+    number = {5},
+    pages = {698--713},
+    title = {{Fuzzy ARTMAP: A Neural Network Architecture for Incremental Supervised Learning of Analog Multidimensional Maps}},
+    volume = {3},
+    year = {1992}
+}
+
+@inproceedings{ARTHestenes1987,
+    abstract = {In spite of the},
+    annote = {From Duplicate 1 (How the Brain Works: The Next Great Scientific Revolution - Hestenes, David)
+
+    David Hestenes, a physicist by training, provides an overview of the adaptive resonance theory of Dr. Stephen Grossberg and its significance to the neuroscience as a whole. He provides evidence for his claim that ART exemplifies a revolution in brain science by giving a historical perspective on the field and illustrating the key points of ART, showing their most significant ramifications. Hestenes provides this paper to make Grossberg's work more accessible, necessary because of the lateral thinking required to appreciate the magnitude of Grossberg's work.
+
+    From Duplicate 2 (How the Brain Works: The Next Great Scientific Revolution - Hestenes, David)
+
+    From Duplicate 3 (How the Brain Works: The Next Great Scientific Revolution - Hestenes, David)
+
+    David Hestenes, a physicist by training, provides an overview of the adaptive resonance theory of Dr. Stephen Grossberg and its significance to the neuroscience as a whole. He provides evidence for his claim that ART exemplifies a revolution in brain science by giving a historical perspective on the field and illustrating the key points of ART, showing their most significant ramifications. Hestenes provides this paper to make Grossberg's work more accessible, necessary because of the lateral thinking required to appreciate the magnitude of Grossberg's work.},
+    author = {Hestenes, David},
+    booktitle = {Maximum-Entropy and Bayesian Spectral Analysis and Estimation Problems},
+    doi = {10.1007/978-94-009-3961-5_11},
+    file = {:C\:/Users/Sasha/AppData/Local/Mendeley Ltd./Mendeley Desktop/Downloaded/Unknown - Unknown - HestenesDavidHowTheBrainWorks001.pdf.pdf:pdf;:C\:/Users/Sasha/AppData/Local/Mendeley Ltd./Mendeley Desktop/Downloaded/Hestenes - 1987 - How the Brain Works The Next Great Scientific Revolution.pdf:pdf},
+    mendeley-groups = {ART},
+    pages = {173--205},
+    publisher = {Springer Netherlands},
+    title = {{How the Brain Works: The Next Great Scientific Revolution}},
+    year = {1987}
+}
+
+@article{Grossberg2017,
+abstract = {The hard problem of consciousness is the problem of explaining how we experience qualia or phenomenal experiences, such as seeing, hearing, and feeling, and knowing what they are. To solve this problem, a theory of consciousness needs to link brain to mind by modeling how emergent properties of several brain mechanisms interacting together embody detailed properties of individual conscious psychological experiences. This article summarizes evidence that Adaptive Resonance Theory, or ART, accomplishes this goal. ART is a cognitive and neural theory of how advanced brains autonomously learn to attend, recognize, and predict objects and events in a changing world. ART has predicted that “all conscious states are resonant states” as part of its specification of mechanistic links between processes of consciousness, learning, expectation, attention, resonance, and synchrony. It hereby provides functional and mechanistic explanations of data ranging from individual spikes and their synchronization to the dynamics of conscious perceptual, cognitive, and cognitive–emotional experiences. ART has reached sufficient maturity to begin classifying the brain resonances that support conscious experiences of seeing, hearing, feeling, and knowing. Psychological and neurobiological data in both normal individuals and clinical patients are clarified by this classification. This analysis also explains why not all resonances become conscious, and why not all brain dynamics are resonant. The global organization of the brain into computationally complementary cortical processing streams (complementary computing), and the organization of the cerebral cortex into characteristic layers of cells (laminar computing), figure prominently in these explanations of conscious and unconscious processes. Alternative models of consciousness are also discussed.},
+author = {Grossberg, Stephen},
+doi = {10.1016/j.neunet.2016.11.003},
+file = {:G\:/My Drive/Research/Literature/ART/Papers/BUpapersSteveGrossbergGailCarpenterEtc/Consciousness2017SteveGrossbergNN.pdf:pdf},
+issn = {18792782},
+journal = {Neural Networks},
+keywords = {Adaptive resonance,Attention,Audition,Consciousness,Emotion,Vision},
+pages = {38--95},
+pmid = {28088645},
+publisher = {Elsevier Ltd},
+title = {{Towards solving the hard problem of consciousness: The varieties of brain resonances and the conscious experiences that they support}},
+url = {http://dx.doi.org/10.1016/j.neunet.2016.11.003},
+volume = {87},
+year = {2017}
+}
+
+@article{Cohen1983a,
+abstract = {The process whereby input patterns are transformed and stored by competitive cellular networks is considered. This process arises in such diverse subjects as the short-term storage of visual or language patterns by neural networks, pattern formation due to the firing of morphogenetic gradients in developmental biology, control of choice behavior during macromolecular evolution, and the design of stable context-sensitive parallel processors. In addition to systems capable of approaching one of perhaps infinitely many equilibrium points in response to arbitrary input patterns and initial data, one finds in these subjects a wide variety of other behaviors, notably traveling waves, standing waves, resonance, and chaos. The question of what general dynamical constraints cause global approach to equilibria rather than large amplitude waves is therefore of considerable interest. In another terminology, this is the question of whether global pattern formation occurs. A related question is whether the global pattern formation property persists when system parameters slowly change in an unpredictable fashion due to self-organization (development, learning). This is the question of absolute stability of global pattern formation. It is shown that many model systems which exhibit the absolute stability property can be written in the form i = 1, 2, {\textperiodcentered}{\textperiodcentered}{\textperiodcentered}, n, where the matrix C = ||c<inf>ik</inf>|| is symmetric and the system as a whole is competitive. Under these circumstances, this system defines a global Liapunov function. The absolute stability of systems with infinite but totally disconnected sets of equilibrium points can then be studied using the LaSalle invariance principle, the theory of several complex variables, and Sard's theorem. The symmetry of matrix C is important since competitive systems of the form (1) exist wherein C is arbitrarily close to a symmetric matrix but almost all trajectories persistently oscillate, as in the voting paradox. Slowing down the competitive feedback without violating symmetry, as in the systems also enables sustained oscillations to occur. Our results thus show that the use of fast symmetric competitive feedback is a robust design constraint for guaranteeing absolute stability of global pattern formation. {\textcopyright} 1983 IEEE},
+author = {Cohen, Michael A. and Grossberg, Stephen},
+doi = {10.1109/TSMC.1983.6313075},
+file = {:C\:/Users/Sasha/AppData/Local/Mendeley Ltd./Mendeley Desktop/Downloaded/Cohen, Grossberg - 1983 - Absolute Stability of Global Pattern Formation and Parallel Memory Storage by Competitive Neural Networks.pdf:pdf},
+issn = {21682909},
+journal = {IEEE Transactions on Systems, Man and Cybernetics},
+number = {5},
+pages = {815--826},
+title = {{Absolute Stability of Global Pattern Formation and Parallel Memory Storage by Competitive Neural Networks}},
+volume = {SMC-13},
+year = {1983}
+}
+
+@article{Grossberg2009,
+abstract = {How do humans rapidly recognize a scene? How can neural models capture this biological competence to achieve state-of-the-art scene classification? The ARTSCENE neural system classifies natural scene photographs by using multiple spatial scales to efficiently accumulate evidence for gist and texture. ARTSCENE embodies a coarse-to-fine Texture Size Ranking Principle whereby spatial attention processes multiple scales of scenic information, from global gist to local textures, to learn and recognize scenic properties. The model can incrementally learn and rapidly predict scene identity by gist information alone, and then accumulate learned evidence from scenic textures to refine this hypothesis. The model shows how texture-fitting allocations of spatial attention, called attentional shrouds, can facilitate scene recognition, particularly when they include a border of adjacent textures. Using grid gist plus three shroud textures on a benchmark photograph dataset, ARTSCENE discriminates 4 landscape scene categories (coast, forest, mountain, and countryside) with up to 91.85% correct on a test set, outperforms alternative models in the literature which use biologically implausible computations, and outperforms component systems that use either gist or texture information alone. {\textcopyright} ARVO.},
+annote = {This paper outlines several different toolchains that together together comprise the ARTSCENE algorithm. The paper at its core is an investigation into the construction of a system that recognizes whole-scene global descriptors from local textures. It does this through a series of image filters that mimik the processing occuring in the mammalian LGN and learning/recognition processing via the Default ARTMAP 2 algorithm.},
+author = {Grossberg, Stephen and Huang, Tsung Ren},
+doi = {10.1167/9.4.6},
+file = {:G\:/My Drive/Research/Literature/ART/jov-9-4-6.pdf:pdf},
+issn = {15347362},
+journal = {Journal of Vision},
+keywords = {ARTMAP,Attentional shroud,Coarse-to-fine processing,Gist,Multiple-scale processing,Scene classification,Spatial attention,Texture},
+mendeley-groups = {ART},
+number = {4},
+pages = {1--19},
+pmid = {19757915},
+title = {{ARTSCENE: A neural system for natural scene classification}},
+volume = {9},
+year = {2009}
+}
+
+@Book{grossberg2021conscious,
+ author = {Grossberg, Stephen},
+ title = {Conscious Mind, Resonant Brain: How Each Brain Makes a Mind},
+ publisher = {OUP Premium Oxford University Press},
+ year = {2021},
+ address = {Oxford, England},
+ isbn = {978-0190070557}
+ }
+
+ @article{Tan2019,
+abstract = {Learning and memory are two intertwined cognitive functions of the human brain. This paper shows how a family of biologically-inspired self-organizing neural networks, known as fusion Adaptive Resonance Theory (fusion ART), may provide a viable approach to realizing the learning and memory functions. Fusion ART extends the single-channel Adaptive Resonance Theory (ART) model to learn multimodal pattern associative mappings. As a natural extension of ART, various forms of fusion ART have been developed for a myriad of learning paradigms, ranging from unsupervised learning to supervised learning, semi-supervised learning, multimodal learning, reinforcement learning, and sequence learning. In addition, fusion ART models may be used for representing various types of memories, notably episodic memory, semantic memory and procedural memory. In accordance with the notion of embodied intelligence, such neural models thus provide a computational account of how an autonomous agent may learn and adapt in a real-world environment. The efficacy of fusion ART in learning and memory shall be discussed through various examples and illustrative case studies.},
+annote = {From Duplicate 1 (Self-organizing neural networks for universal learning and multimodal memory encoding - Tan, Ah-Hwee Hwee; Subagdja, Budhitama; Wang, Di; Meng, Lei)
+
+This paper is effectively an appraisal of the Fusion ART algorithm, effectively outlining the details of the algorithm, its capabilities, and its limitations. The paper outlines some practical applications of this algorithm, especially as backbone for other algorithms (i.e., FALCON, iFALCON, EM-ART, OMC-ART, etc.).
+},
+author = {Tan, Ah-Hwee Hwee and Subagdja, Budhitama and Wang, Di and Meng, Lei},
+doi = {10.1016/j.neunet.2019.08.020},
+file = {:C\:/Users/Sasha/AppData/Local/Mendeley Ltd./Mendeley Desktop/Downloaded/Tan et al. - 2019 - Self-organizing neural networks for universal learning and multimodal memory encoding.pdf:pdf;:C\:/Users/Sasha/AppData/Local/Mendeley Ltd./Mendeley Desktop/Downloaded/Tan et al. - 2019 - Self-organizing neural networks for universal learning and multimodal memory encoding(2).pdf:pdf},
+issn = {08936080},
+journal = {Neural Networks},
+keywords = {,Adaptive resonance theory,Memory encoding,Universal learning,adaptive resonance theory},
+mendeley-groups = {ART,NN Special Issue},
+number = {xxxx},
+pages = {58--73},
+publisher = {Elsevier Ltd},
+title = {{Self-organizing neural networks for universal learning and multimodal memory encoding}},
+url = {https://doi.org/10.1016/j.neunet.2019.08.020},
+volume = {120},
+year = {2019}
+}

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -23,12 +23,52 @@ bibliography: paper.bib
 AdaptiveResonance.jl is a Julia package for machine learning with Adaptive Resonance Theory (ART) algorithms, written in the numerical computing language Julia.
 ART is a neurocognitive theory of how competitive cellular networks can learn distributed patterns without supervision through recurrent field connections, eliciting the mechanisms of perception, expectation, and recognition [@Grossberg2013; @Grossberg1980].
 
-# Statement of need
+# Statement of Need
 
 There exist many variations of algorithms built upon ART [@DaSilva2019].
 Each variation is related by utilizing recurrent connections of fields, driven by learning through match and mismatch of distributed patterns, and though they all differ in the details of their implementations, their algorithmic and programmatic requirements are often very similar.
 Despite the relevance and successes of this class of algorithms in the literature, there does not exist to date a unified repository of their implementations in Julia.
 The purpose of this package is to create a unified framework and repository of ART algorithms in Julia.
+
+## Target Audience
+
+This package is principally intended as a resource for researchers in machine learning and adaptive resonance theory for testing and developing new ART algorithms.
+However, implementing these algorithms in the Julia language brings all of the benefits of the Julia itself, such as the speed of being implemented in a low-level language such as C while having the transparency of a high-level language such as MATLAB.
+Being implemented in Julia allows the package to be understood and expanded upon by research scientists while still being able to be used in resource-demanding production environments.
+
+# Adaptive Resonance Theory
+
+ART is originally a theory of how competitive fields of neurons interact to form stable representations without supervision, and ART algorithms draw from this theory as biological inspiration for their design.
+It is not strictly necessary to have an understanding of the theory to understand the use of the algorithms, but they share a common nomenclature that makes knowledge of the former useful for the latter.
+
+## Theory
+
+Adaptive resonance theory is a collection of neurological study from the neuron level to the network level [@ARTHestenes1987].
+ART begins with a set of neural field differential equations, and the theory tackles problems from why sigmoidal activations are used and the conditions of stability for competitive neural networks [@Cohen1983a] to how the mammalian visual system works [@Grossberg2009] and the hard problem of consciousness linking resonant states to conscious experiences [@Grossberg2017].
+Stephen Grossberg and Gail Carpenter have published many resources for learning the theory and its history in detail [@grossberg2021conscious].
+
+## Algorithms
+
+ART algorithms are generally characterized in behavior by the following:
+
+1. They are inherently *unsupervised* learning algorithms at their core, but they have been adapted to supervised and reinforcement learning paradigms with frameworks such as ARTMAP [@Carpenter1991; @Carpenter1992] and FALCON [@Tan2019], respectively.
+2. They are *incremental* learning algorithms, adjusting their weights or creating new ones at every sample presentation.
+3. They are *neurogenesis* neural networks, representing their learning by the modification of existing prototype weights or instantiating new ones entirely.
+4. They belong to the class of *competitive* neural networks, which compute their outputs with more complex dynamics than feedforward activation.
+
+Because of the breadth of the original theory and variety of possible applications, ART-based algorithms are diverse in their implementation details.
+Nevertheless, they are generally structured as follows:
+
+1. ART models typically have two layers/fields denoted F1 and F2.
+2. The F1 field is the feature representation field.
+Most often, it is simply the input feature sample itself (after some necessary preprocessing).
+3. The F2 field is the category representation field.
+With some exceptions, each node in the F2 field represents its own category.
+This is most easily understood as a weight vector representing a prototype for a class or centroid of a cluster.
+4. An activation function is used to find the order of categories "most activated" for a given sample in F1.
+5. In order of highest activation, a match function is used to compute the agreement between the sample and the categories.
+6. If the match function for a category evaluates to a value above a threshold known as the vigilance parameter ($$\rho$$), the weights of that category may be updated according to a learning rule.
+7. If there is complete mismatch across all categories, then a new categories is created according to some instantiation rule.
 
 # Acknowledgements
 


### PR DESCRIPTION
This PR adds a target audience section under the statement of need. It also adds an ART section that explains the basics of the theory and algorithms. More citations are added under both.