### PR TITLE
Add get_bmu sections to docs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,44 @@ opts = opts_DDVFA(rho_ub=0.75, rho_lb=0.4)
 art = DDVFA(opts)
 ```
 
+Train and test the models with `train!` and `classify`:
+
+```julia
+# Unsupervised ART module
+art = DDVFA()
+
+# Supervised ARTMAP module
+artmap = SFAM()
+
+# Load some data
+train_x, train_y, test_x, test_y = load_your_data()
+
+# Unsupervised training and testing
+train!(art, train_x)
+y_hat_art = classify(art, test_x)
+
+# Supervised training and testing
+train!(artmap, train_x, train_y)
+y_hat_artmap = classify(art, test_x)
+```
+
+`train!` and `classify` can accept incremental or batch data, where rows are features and columns are samples.
+
+Unsupervised ART modules can also accommodate simple supervised learning where internal categories are mapped to supervised labels with the keyword argument `y`:
+
+```julia
+# Unsupervised ART module
+art = DDVFA()
+train!(art, train_x, y=train_y)
+```
+
+These modules also support retrieving the "best-matching unit" in the case of complete mismatch (i.e., the next-best category if the presented sample is completely unrecognized) with the keyword argument `get_bmu`:
+
+```julia
+# Get the best-matching unit in the case of complete mismatch
+y_hat_bmu = classify(art, test_x, get_bmu=true)
+```
+
 ## Implemented Modules
 
 This project has implementations of the following ART (unsupervised) and ARTMAP (supervised) modules:

--- a/docs/src/man/guide.md
+++ b/docs/src/man/guide.md
@@ -39,6 +39,7 @@ To work with ART modules, you should know:
 - [Their basic methods](@ref methods)
 - [Incremental vs. batch modes](@ref incremental_vs_batch)
 - [Supervised vs. unsupervised learning modes](@ref supervised_vs_unsupervised)
+- [Mismatch vs. Best-Matching-Unit](@ref mismatch-bmu)
 
 ### [Methods](@id methods)
 
@@ -162,6 +163,19 @@ perf_test = performance(y_hat_test, test_y)
 ```
 
 However, many ART modules, though unsupervised by definition, can also be trained in a supervised way by naively mapping categories to labels (more in [ART vs. ARTMAP](@ref art_vs_artmap)).
+
+### [Mismatch vs. Best-Matching-Unit](@id mismatch-bmu)
+
+During inference, ART algorithms report the category that satisfies the match/vigilance criterion (see [Background](@ref)).
+By default, in the case that no category satisfies this criterion the module reports a *mismatch* as -1.
+In modules that support it, a keyword argument `get_bmu` (default is `false`) can be used in the `classify` method to get the "best-matching unit", which is the category that maximizes the activation.
+This can be interpreted as the "next-best guess" of the model in the case that the sample is sufficiently different from anything that the model has seen.
+For example,
+
+```julia
+# Conduct inference, getting the best-matching unit in case of complete mismatch
+y_hat_bmu = classify(my_art, test_x, get_bmu=true)
+```
 
 ## [ART Options](@id art_options)
 


### PR DESCRIPTION
This PR explains the mismatch and `get_bmu` usage in the docs and README. The README quickstart has more basic usage added for training and inference.