### PR TITLE
Feature/x86 support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
           - windows-latest
         arch:
           - x64
-          # - x86
+          - x86
         # exclude:
           # Test 32-bit only on Linux
           # - os: macOS-latest


### PR DESCRIPTION
This PR begins development of x86 support by levering the GitHub actions CI. This issue should only close once all tests pass.