### PR TITLE
feature/macOS-support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
           - "1"    # Latest Release
         os:
           - ubuntu-latest
-          # - macOS-latest
+          - macOS-latest
           - windows-latest
         arch:
           - x64


### PR DESCRIPTION
This PR begins development for macOS support by leveraging the GitHub actions CI for testing. This PR should only close when all tests pass for macOS.