### PR TITLE
Add with lfs to docs github action

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -20,6 +20,8 @@ jobs:
           access_token: ${{ github.token }}
 
       - uses: actions/checkout@v2
+        with:
+          lfs: 'true'
       - uses: julia-actions/setup-julia@latest
         with:
           version: '1.8'


### PR DESCRIPTION
This PR updates the documentation github action to use LFS to pull the docs LFS images and other assets.