### PR TITLE
Feature/link modules to index

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Please read the [documentation](https://ap6yc.github.io/AdaptiveResonance.jl/dev
 - [Installation](#installation)
 - [Quickstart](#quickstart)
 - [Implemented Modules](#implemented-modules)
-- [Structure](#structure)
 - [History](#history)
 - [Acknowledgements](#acknowledgements)
   - [Authors](#authors)
@@ -201,31 +200,6 @@ In addition to these modules, this package contains the following accessory meth
 - **complement_code**: complement coding is implemented with `complement_code`.
 However, training and classification methods complement code their inputs unless they are passed `preprocessed=true`.
 - **linear_normalization**: the first step to complement coding, `linear_normalization` normalizes input arrays within [0, 1].
-
-## Structure
-
-The following file tree summarizes the project structure:
-
-```console
-AdaptiveResonance
-├── .github/workflows       // GitHub: workflows for testing and documentation.
-├── docs                    // Docs: documentation for the module.
-│   ├─── examples           //      DemoCards documentation examples.
-│   └─── src                //      Documentation source files.
-├── paper                   // JOSS: journal paper and citations.
-├── src                     // Source: majority of source code.
-│   ├─── ART                //      ART-based unsupervised modules.
-│   └─── ARTMAP             //      ARTMAP-based supervised modules.
-├── test                    // Test: Unit, integration, and environment tests.
-├── .appveyor               // Appveyor: Windows-specific coverage.
-├── .gitattributes          // Git: LFS settings, languages, etc.
-├── .gitignore              // Git: .gitignore for the whole project.
-├── CODE_OF_CONDUCT.md      // Doc: the code of conduct for contributors.
-├── CONTRIBUTING.md         // Doc: contributing guide (points to this page).
-├── LICENSE                 // Doc: the license to the project.
-├── Project.toml            // Julia: the Pkg.jl dependencies of the project.
-└── README.md               // Doc: this document.
-```
 
 ## History
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ However, training and classification methods complement code their inputs unless
 - 11/3/2020 - Complete baseline modules and tests.
 - 2/8/2021 - Formalize usage documentation.
 - 10/13/2021 - Initiate GitFlow contribution.
+- 5/4/2022 - [Acceptance to JOSS](https://doi.org/10.21105/joss.03671).
+- 10/11/2022 - v0.6.0
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -183,13 +183,20 @@ y_hat_bmu = classify(art, test_x, get_bmu=true)
 This project has implementations of the following ART (unsupervised) and ARTMAP (supervised) modules:
 
 - ART
-  - **FuzzyART**: Fuzzy ART
-  - **DVFA**: Dual Vigilance Fuzzy ART
-  - **DDVFA**: Distributed Dual Vigilance Fuzzy ART
+  - **[`FuzzyART`][1]**: Fuzzy ART
+  - **[`DVFA`][2]**: Dual Vigilance Fuzzy ART
+  - **[`DDVFA`][3]**: Distributed Dual Vigilance Fuzzy ART
 - ARTMAP
-  - **SFAM**: Simplified Fuzzy ARTMAP
-  - **FAM**: Fuzzy ARTMAP
-  - **DAM**: Default ARTMAP
+  - **[`SFAM`][4]**: Simplified Fuzzy ARTMAP
+  - **[`FAM`][5]**: Fuzzy ARTMAP
+  - **[`DAM`][6]**: Default ARTMAP
+
+[1]: https://ap6yc.github.io/AdaptiveResonance.jl/dev/man/full-index/#AdaptiveResonance.FuzzyART
+[2]: https://ap6yc.github.io/AdaptiveResonance.jl/dev/man/full-index/#AdaptiveResonance.DVFA
+[3]: https://ap6yc.github.io/AdaptiveResonance.jl/dev/man/full-index/#AdaptiveResonance.DDVFA
+[4]: https://ap6yc.github.io/AdaptiveResonance.jl/dev/man/full-index/#AdaptiveResonance.SFAM
+[5]: https://ap6yc.github.io/AdaptiveResonance.jl/dev/man/full-index/#AdaptiveResonance.FAM
+[6]: https://ap6yc.github.io/AdaptiveResonance.jl/dev/man/full-index/#AdaptiveResonance.DAM
 
 Because each of these modules is a framework for many variants in the literature, this project also implements these [variants](https://ap6yc.github.io/AdaptiveResonance.jl/dev/man/modules/) by changing their module [options](https://ap6yc.github.io/AdaptiveResonance.jl/dev/man/guide/#art_options).
 

--- a/docs/src/man/guide.md
+++ b/docs/src/man/guide.md
@@ -243,7 +243,7 @@ Otherwise, most ART and ARTMAP modules share the following nomenclature for algo
 ART modules are generally unsupervised in formulation, so they do not explicitly require supervisory labels to their training examples.
 However, many of these modules can be formulated in the simplified ARTMAP style whereby the ART B module has a vigilance parameter of 1, directly mapping the categories of the ART A module to any provided supervisory labels.
 
-This is done in the training stage through the optional argument `y=...`:
+This is done in the training stage through the optional keyword argument `y=...`:
 
 ```julia
 # Create an arbitrary ART module

--- a/docs/src/man/modules.md
+++ b/docs/src/man/modules.md
@@ -2,20 +2,24 @@
 
 This project implements a number of ART-based models with options that modulate their behavior (see the [options section of the Guide](@ref art_options))
 
-This page lists both the [implemented models](@ref Implemented-Models) and some [variants](@ref Variants)
+This page lists both the [implemented models](@ref Implemented-Models) and some of their [variants](@ref variants)
 
 ## Implemented Models
 
 This project has implementations of the following ART (unsupervised) and ARTMAP (supervised) modules:
 
+```@meta
+CurrentModule=AdaptiveResonance
+```
+
 - ART
-  - `FuzzyART`: Fuzzy ART
-  - `DVFA`: Dual Vigilance Fuzzy ART
-  - `DDVFA`: Distributed Dual Vigilance Fuzzy ART
+  - [`FuzzyART`](@ref): Fuzzy ART
+  - [`DVFA`](@ref): Dual Vigilance Fuzzy ART
+  - [`DDVFA`](@ref): Distributed Dual Vigilance Fuzzy ART
 - ARTMAP
-  - `SFAM`: Simplified Fuzzy ARTMAP
-  - `FAM`: Fuzzy ARTMAP
-  - `DAM`: Default ARTMAP
+  - [`SFAM`](@ref): Simplified Fuzzy ARTMAP
+  - [`FAM`](@ref): Fuzzy ARTMAP
+  - [`DAM`](@ref): Default ARTMAP
 
 ## Variants
 

--- a/docs/src/man/modules.md
+++ b/docs/src/man/modules.md
@@ -2,7 +2,7 @@
 
 This project implements a number of ART-based models with options that modulate their behavior (see the [options section of the Guide](@ref art_options))
 
-This page lists both the [implemented models](@ref Implemented-Models) and some of their [variants](@ref variants)
+This page lists both the [implemented models](@ref Implemented-Models) and some of their [variants](@ref modules-variants)
 
 ## Implemented Models
 
@@ -21,7 +21,7 @@ CurrentModule=AdaptiveResonance
   - [`FAM`](@ref): Fuzzy ARTMAP
   - [`DAM`](@ref): Default ARTMAP
 
-## Variants
+## [Variants](@id modules-variants)
 
 Each module contains many [options](@ref art_options) that modulate its behavior.
 Some of these options are used to modulate the internals of the module, such as switching the match and activation functions, to achieve different modules that are found in the literature.


### PR DESCRIPTION
This PR updates the documentation in various ways, such as by including functioning links to the various ART/ARTMAP modules when they are listed in the README and hosted documentation.