### PR TITLE
Update pins for GitHub actions node update

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,16 +41,16 @@ jobs:
       # Cancel ongoing tests if pushing to branch again before the previous
       # build is finished.
       - name: Cancel ongoing tests for previous commits
-        uses: styfle/cancel-workflow-action@0.6.0
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         env:
           cache-name: cache-artifacts
         with:
@@ -69,7 +69,7 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
 
       - name: Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           file: lcov.info
 


### PR DESCRIPTION
This PR updates the pins for the GitHub actions that use node 16.