### PR TITLE
Specify master branch for tagbot

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -13,3 +13,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}
+          branch: master


### PR DESCRIPTION
This PR specifies the `master` branch for the Julia TagBot.